### PR TITLE
Add datetime support

### DIFF
--- a/src/components/steps/BasicInfoStep.tsx
+++ b/src/components/steps/BasicInfoStep.tsx
@@ -1,7 +1,7 @@
 import { useFormContext } from 'react-hook-form';
 import { Label } from '../ui/label';
 import { Input } from '../ui/input';
-import { DatePicker } from '../ui/date-picker';
+import { DateTimePicker } from '../ui/datetime-picker';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 
 export function BasicInfoStep() {
@@ -94,11 +94,12 @@ export function BasicInfoStep() {
 
         <div className="space-y-2">
           <Label htmlFor="startDate">Start Date <span className="required-asterisk">*</span></Label>
-          <DatePicker
+          <DateTimePicker
             id="startDate"
             value={watch('startDate')}
             onChange={(value) => setValue('startDate', value)}
             placeholder="Select start date"
+            includeTime
             required
           />
         </div>
@@ -122,11 +123,12 @@ export function BasicInfoStep() {
         {campaignStatus === 'historical' && (
           <div className="space-y-2">
             <Label htmlFor="endDate">End Date <span className="required-asterisk">*</span></Label>
-            <DatePicker
+            <DateTimePicker
               id="endDate"
               value={watch('endDate') || ''}
               onChange={(value) => setValue('endDate', value)}
               placeholder="Select end date"
+              includeTime
               required
             />
           </div>

--- a/src/components/steps/LocationStep.tsx
+++ b/src/components/steps/LocationStep.tsx
@@ -4,7 +4,7 @@ import { ChevronDown, PlusCircle, Trash2 } from 'lucide-react';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
-import { DatePicker } from '../ui/date-picker';
+import { DateTimePicker } from '../ui/datetime-picker';
 import { Textarea } from '../ui/textarea';
 import { Map } from '../ui/map';
 import { Button } from '../ui/button';
@@ -230,7 +230,7 @@ export function LocationStep() {
                       <Label htmlFor="measurement_location.0.mast_properties.date_from">
                         Date From
                       </Label>
-                      <DatePicker
+                      <DateTimePicker
                         value={watch('measurement_location.0.mast_properties.date_from') || ''}
                         onChange={(value) => setValue('measurement_location.0.mast_properties.date_from', value)}
                         placeholder="Select start date and time"
@@ -242,7 +242,7 @@ export function LocationStep() {
                       <Label htmlFor="measurement_location.0.mast_properties.date_to">
                         Date To
                       </Label>
-                      <DatePicker
+                      <DateTimePicker
                         value={watch('measurement_location.0.mast_properties.date_to') || ''}
                         onChange={(value) => setValue('measurement_location.0.mast_properties.date_to', value)}
                         placeholder="Select end date and time"
@@ -399,7 +399,7 @@ export function LocationStep() {
                               <Label htmlFor={`measurement_location.0.vertical_profiler_properties.${index}.date_from`}>
                                 Date From
                               </Label>
-                              <DatePicker
+                              <DateTimePicker
                                 value={watch(`measurement_location.0.vertical_profiler_properties.${index}.date_from`) || ''}
                                 onChange={(value) => setValue(`measurement_location.0.vertical_profiler_properties.${index}.date_from`, value)}
                                 placeholder="Select start date and time"
@@ -411,7 +411,7 @@ export function LocationStep() {
                               <Label htmlFor={`measurement_location.0.vertical_profiler_properties.${index}.date_to`}>
                                 Date To
                               </Label>
-                              <DatePicker
+                              <DateTimePicker
                                 value={watch(`measurement_location.0.vertical_profiler_properties.${index}.date_to`) || ''}
                                 onChange={(value) => setValue(`measurement_location.0.vertical_profiler_properties.${index}.date_to`, value)}
                                 placeholder="Select end date and time"

--- a/src/components/steps/LoggerStep.tsx
+++ b/src/components/steps/LoggerStep.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
-import { DatePicker } from '../ui/date-picker';
+import { DateTimePicker } from '../ui/datetime-picker';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import { Textarea } from '../ui/textarea';
 import type { IEATask43Schema, LoggerOEM } from '../../types/schema';
@@ -226,7 +226,7 @@ export function LoggerStep() {
                             <Label htmlFor={`measurement_location.${locationIndex}.logger_main_config.${loggerIndex}.date_from`}>
                                 Date From <span className="required-asterisk">*</span>
                               </Label>
-                            <DatePicker
+                            <DateTimePicker
                               value={watch(`measurement_location.${locationIndex}.logger_main_config.${loggerIndex}.date_from`) || ''}
                               onChange={(value) => setValue(`measurement_location.${locationIndex}.logger_main_config.${loggerIndex}.date_from`, value)}
                               placeholder="Select start date and time"
@@ -239,7 +239,7 @@ export function LoggerStep() {
                             <Label htmlFor={`measurement_location.${locationIndex}.logger_main_config.${loggerIndex}.date_to`}>
                                 Date To <span className="required-asterisk">*</span>
                               </Label>
-                            <DatePicker
+                            <DateTimePicker
                               value={watch(`measurement_location.${locationIndex}.logger_main_config.${loggerIndex}.date_to`) || ''}
                               onChange={(value) => setValue(`measurement_location.${locationIndex}.logger_main_config.${loggerIndex}.date_to`, value)}
                               placeholder="Select end date and time"

--- a/src/components/steps/SensorStep.tsx
+++ b/src/components/steps/SensorStep.tsx
@@ -4,7 +4,7 @@ import { PlusCircle, Trash2, ChevronDown, Plus, Copy } from 'lucide-react';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
-import { DatePicker } from '../ui/date-picker';
+import { DateTimePicker } from '../ui/datetime-picker';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import { Textarea } from '../ui/textarea';
 import type { IEATask43Schema, SensorType, MeasurementType } from '../../types/schema';
@@ -384,7 +384,7 @@ function LocationSensorsManager({
   <Label htmlFor={`measurement_location.${locationIndex}.sensors.${sensorsIndex}.date_from`}>
     Date From <span className="required-asterisk">*</span>
   </Label>
-  <DatePicker
+  <DateTimePicker
     value={watch(`measurement_location.${locationIndex}.sensors.${sensorsIndex}.date_from`) || ''}
     onChange={(value) => setValue(`measurement_location.${locationIndex}.sensors.${sensorsIndex}.date_from`, value)}
     placeholder="Select start date and time"
@@ -400,7 +400,7 @@ function LocationSensorsManager({
   <Label htmlFor={`measurement_location.${locationIndex}.sensors.${sensorsIndex}.date_to`}>
     Date To <span className="required-asterisk">*</span>
   </Label>
-  <DatePicker
+  <DateTimePicker
     value={watch(`measurement_location.${locationIndex}.sensors.${sensorsIndex}.date_to`) || ''}
     onChange={(value) => setValue(`measurement_location.${locationIndex}.sensors.${sensorsIndex}.date_to`, value)}
     placeholder="Select end date and time"
@@ -635,10 +635,11 @@ function CalibrationArray({
                   <Label htmlFor={`measurement_location.${locationIndex}.sensors.${sensorsIndex}.calibration.${calIndex}.date_of_calibration`}>
                     Calibration Date
                   </Label>
-                  <DatePicker
+                  <DateTimePicker
                     value={watch(`measurement_location.${locationIndex}.sensors.${sensorsIndex}.calibration.${calIndex}.date_of_calibration`) || ''}
                     onChange={(value) => setValue(`measurement_location.${locationIndex}.sensors.${sensorsIndex}.calibration.${calIndex}.date_of_calibration`, value)}
                     placeholder="Select calibration date"
+                    includeTime
                   />
                 </div>
 


### PR DESCRIPTION
## Summary
- migrate the date picker to a DateTime picker component with optional time
- update wizard steps to use the new DateTimePicker

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6859b70601cc8330847ff70990f25d0d