### PR TITLE
Add time support to date picker

### DIFF
--- a/src/components/steps/BasicInfoStep.tsx
+++ b/src/components/steps/BasicInfoStep.tsx
@@ -1,7 +1,7 @@
 import { useFormContext } from 'react-hook-form';
 import { Label } from '../ui/label';
 import { Input } from '../ui/input';
-import { DatePicker } from '../ui/date-picker';
+import { DateTimePicker } from '../ui/datetime-picker';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 
 export function BasicInfoStep() {
@@ -94,7 +94,7 @@ export function BasicInfoStep() {
 
         <div className="space-y-2">
           <Label htmlFor="startDate">Start Date <span className="required-asterisk">*</span></Label>
-          <DatePicker
+          <DateTimePicker
             id="startDate"
             value={watch('startDate')}
             onChange={(value) => setValue('startDate', value)}
@@ -122,7 +122,7 @@ export function BasicInfoStep() {
         {campaignStatus === 'historical' && (
           <div className="space-y-2">
             <Label htmlFor="endDate">End Date <span className="required-asterisk">*</span></Label>
-            <DatePicker
+            <DateTimePicker
               id="endDate"
               value={watch('endDate') || ''}
               onChange={(value) => setValue('endDate', value)}

--- a/src/components/steps/LocationStep.tsx
+++ b/src/components/steps/LocationStep.tsx
@@ -4,7 +4,7 @@ import { ChevronDown, PlusCircle, Trash2 } from 'lucide-react';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
-import { DatePicker } from '../ui/date-picker';
+import { DateTimePicker } from '../ui/datetime-picker';
 import { Textarea } from '../ui/textarea';
 import { Map } from '../ui/map';
 import { Button } from '../ui/button';
@@ -230,11 +230,10 @@ export function LocationStep() {
                       <Label htmlFor="measurement_location.0.mast_properties.date_from">
                         Date From
                       </Label>
-                      <DatePicker
+                      <DateTimePicker
                         value={watch('measurement_location.0.mast_properties.date_from') || ''}
                         onChange={(value) => setValue('measurement_location.0.mast_properties.date_from', value)}
                         placeholder="Select start date and time"
-                        includeTime
                       />
                     </div>
 
@@ -242,11 +241,10 @@ export function LocationStep() {
                       <Label htmlFor="measurement_location.0.mast_properties.date_to">
                         Date To
                       </Label>
-                      <DatePicker
+                      <DateTimePicker
                         value={watch('measurement_location.0.mast_properties.date_to') || ''}
                         onChange={(value) => setValue('measurement_location.0.mast_properties.date_to', value)}
                         placeholder="Select end date and time"
-                        includeTime
                       />
                     </div>
 
@@ -399,11 +397,10 @@ export function LocationStep() {
                               <Label htmlFor={`measurement_location.0.vertical_profiler_properties.${index}.date_from`}>
                                 Date From
                               </Label>
-                              <DatePicker
+                              <DateTimePicker
                                 value={watch(`measurement_location.0.vertical_profiler_properties.${index}.date_from`) || ''}
                                 onChange={(value) => setValue(`measurement_location.0.vertical_profiler_properties.${index}.date_from`, value)}
                                 placeholder="Select start date and time"
-                                includeTime
                               />
                             </div>
 
@@ -411,11 +408,10 @@ export function LocationStep() {
                               <Label htmlFor={`measurement_location.0.vertical_profiler_properties.${index}.date_to`}>
                                 Date To
                               </Label>
-                              <DatePicker
+                              <DateTimePicker
                                 value={watch(`measurement_location.0.vertical_profiler_properties.${index}.date_to`) || ''}
                                 onChange={(value) => setValue(`measurement_location.0.vertical_profiler_properties.${index}.date_to`, value)}
                                 placeholder="Select end date and time"
-                                includeTime
                               />
                             </div>
 

--- a/src/components/steps/LoggerStep.tsx
+++ b/src/components/steps/LoggerStep.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
-import { DatePicker } from '../ui/date-picker';
+import { DateTimePicker } from '../ui/datetime-picker';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import { Textarea } from '../ui/textarea';
 import type { IEATask43Schema, LoggerOEM } from '../../types/schema';
@@ -226,11 +226,10 @@ export function LoggerStep() {
                             <Label htmlFor={`measurement_location.${locationIndex}.logger_main_config.${loggerIndex}.date_from`}>
                                 Date From <span className="required-asterisk">*</span>
                               </Label>
-                            <DatePicker
+                            <DateTimePicker
                               value={watch(`measurement_location.${locationIndex}.logger_main_config.${loggerIndex}.date_from`) || ''}
                               onChange={(value) => setValue(`measurement_location.${locationIndex}.logger_main_config.${loggerIndex}.date_from`, value)}
                               placeholder="Select start date and time"
-                              includeTime
                               required
                             />
                           </div>
@@ -239,11 +238,10 @@ export function LoggerStep() {
                             <Label htmlFor={`measurement_location.${locationIndex}.logger_main_config.${loggerIndex}.date_to`}>
                                 Date To <span className="required-asterisk">*</span>
                               </Label>
-                            <DatePicker
+                            <DateTimePicker
                               value={watch(`measurement_location.${locationIndex}.logger_main_config.${loggerIndex}.date_to`) || ''}
                               onChange={(value) => setValue(`measurement_location.${locationIndex}.logger_main_config.${loggerIndex}.date_to`, value)}
                               placeholder="Select end date and time"
-                              includeTime
                               required
                             />
                           </div>

--- a/src/components/steps/SensorStep.tsx
+++ b/src/components/steps/SensorStep.tsx
@@ -4,7 +4,7 @@ import { PlusCircle, Trash2, ChevronDown, Plus, Copy } from 'lucide-react';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
-import { DatePicker } from '../ui/date-picker';
+import { DateTimePicker } from '../ui/datetime-picker';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import { Textarea } from '../ui/textarea';
 import type { IEATask43Schema, SensorType, MeasurementType } from '../../types/schema';
@@ -384,11 +384,10 @@ function LocationSensorsManager({
   <Label htmlFor={`measurement_location.${locationIndex}.sensors.${sensorsIndex}.date_from`}>
     Date From <span className="required-asterisk">*</span>
   </Label>
-  <DatePicker
+  <DateTimePicker
     value={watch(`measurement_location.${locationIndex}.sensors.${sensorsIndex}.date_from`) || ''}
     onChange={(value) => setValue(`measurement_location.${locationIndex}.sensors.${sensorsIndex}.date_from`, value)}
     placeholder="Select start date and time"
-    includeTime
     required
     className={errors?.measurement_location?.[locationIndex]?.sensor?.[sensorsIndex]?.date_from ? 'border-red-500' : ''}
   />
@@ -400,11 +399,10 @@ function LocationSensorsManager({
   <Label htmlFor={`measurement_location.${locationIndex}.sensors.${sensorsIndex}.date_to`}>
     Date To <span className="required-asterisk">*</span>
   </Label>
-  <DatePicker
+  <DateTimePicker
     value={watch(`measurement_location.${locationIndex}.sensors.${sensorsIndex}.date_to`) || ''}
     onChange={(value) => setValue(`measurement_location.${locationIndex}.sensors.${sensorsIndex}.date_to`, value)}
     placeholder="Select end date and time"
-    includeTime
     required
     className={errors?.measurement_location?.[locationIndex]?.sensor?.[sensorsIndex]?.date_to ? 'border-red-500' : ''}
   />
@@ -635,10 +633,10 @@ function CalibrationArray({
                   <Label htmlFor={`measurement_location.${locationIndex}.sensors.${sensorsIndex}.calibration.${calIndex}.date_of_calibration`}>
                     Calibration Date
                   </Label>
-                  <DatePicker
+                  <DateTimePicker
                     value={watch(`measurement_location.${locationIndex}.sensors.${sensorsIndex}.calibration.${calIndex}.date_of_calibration`) || ''}
                     onChange={(value) => setValue(`measurement_location.${locationIndex}.sensors.${sensorsIndex}.calibration.${calIndex}.date_of_calibration`, value)}
-                    placeholder="Select calibration date"
+                    placeholder="Select calibration date and time"
                   />
                 </div>
 

--- a/src/components/ui/datetime-picker.tsx
+++ b/src/components/ui/datetime-picker.tsx
@@ -13,7 +13,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover"
 
-interface DatePickerProps {
+interface DateTimePickerProps {
   id?: string
   value?: string
   onChange: (value: string) => void
@@ -43,7 +43,7 @@ function isValidDate(date: Date | undefined) {
   return !isNaN(date.getTime())
 }
 
-export function DatePicker({
+export function DateTimePicker({
   id,
   value,
   onChange,
@@ -52,11 +52,12 @@ export function DatePicker({
   label,
   disabled = false,
   className,
-}: DatePickerProps) {
+}: DateTimePickerProps) {
   const [open, setOpen] = React.useState(false)
   const [date, setDate] = React.useState<Date | undefined>()
   const [month, setMonth] = React.useState<Date | undefined>()
   const [inputValue, setInputValue] = React.useState("")
+  const [timeValue, setTimeValue] = React.useState("00:00")
 
   // Initialize from value prop
   React.useEffect(() => {
@@ -66,11 +67,13 @@ export function DatePicker({
         setDate(parsedDate)
         setMonth(parsedDate)
         setInputValue(formatDate(parsedDate))
+        setTimeValue(parsedDate.toISOString().substring(11, 16))
       }
     } else {
       setDate(undefined)
       setMonth(undefined)
       setInputValue("")
+      setTimeValue("00:00")
     }
   }, [value])
 
@@ -78,7 +81,10 @@ export function DatePicker({
     setDate(selectedDate)
     setInputValue(formatDate(selectedDate))
     if (selectedDate) {
-      onChange(selectedDate.toISOString().split('T')[0])
+      const [hours, minutes] = timeValue.split(":").map(Number)
+      selectedDate.setHours(hours || 0)
+      selectedDate.setMinutes(minutes || 0)
+      onChange(selectedDate.toISOString())
     } else {
       onChange("")
     }
@@ -93,7 +99,10 @@ export function DatePicker({
     if (isValidDate(parsedDate)) {
       setDate(parsedDate)
       setMonth(parsedDate)
-      onChange(parsedDate.toISOString().split('T')[0])
+      const [hours, minutes] = timeValue.split(":").map(Number)
+      parsedDate.setHours(hours || 0)
+      parsedDate.setMinutes(minutes || 0)
+      onChange(parsedDate.toISOString())
     }
   }
 
@@ -149,6 +158,24 @@ export function DatePicker({
             />
           </PopoverContent>
         </Popover>
+        <Input
+          type="time"
+          value={timeValue}
+          className="w-28"
+          disabled={disabled}
+          required={required}
+          onChange={(e) => {
+            const newTime = e.target.value
+            setTimeValue(newTime)
+            if (date) {
+              const updated = new Date(date)
+              const [h, m] = newTime.split(":").map(Number)
+              updated.setHours(h || 0)
+              updated.setMinutes(m || 0)
+              onChange(updated.toISOString())
+            }
+          }}
+        />
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- rename `DatePicker` to `DateTimePicker`
- extend picker with time selection
- replace all `DatePicker` usages with `DateTimePicker`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6859b70601cc8330847ff70990f25d0d