### PR TITLE
Move step validations inline

### DIFF
--- a/src/components/ValidationSummary.tsx
+++ b/src/components/ValidationSummary.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Check, AlertCircle } from 'lucide-react';
+import { cn } from '../utils/cn';
+import type { ValidationResult } from '../utils/validation';
+
+interface Props {
+  title: string;
+  result: ValidationResult;
+}
+
+export function ValidationSummary({ title, result }: Props) {
+  return (
+    <div
+      className={cn(
+        'p-4 rounded-lg border mb-6',
+        result.valid ? 'bg-green-50 border-green-200' : 'bg-red-50 border-red-200'
+      )}
+    >
+      <div className="flex items-center gap-2 mb-2">
+        {result.valid ? (
+          <Check className="w-5 h-5 text-green-500" />
+        ) : (
+          <AlertCircle className="w-5 h-5 text-red-500" />
+        )}
+        <h3 className="text-base font-medium">{title}</h3>
+      </div>
+      {!result.valid && result.issues.length > 0 && (
+        <ul className="mt-2 space-y-1 text-sm text-red-700">
+          {result.issues.map((issue, index) => (
+            <li key={index} className="flex items-start gap-2">
+              <span className="select-none">•</span>
+              <span>{issue}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/steps/BasicInfoStep.tsx
+++ b/src/components/steps/BasicInfoStep.tsx
@@ -3,11 +3,14 @@ import { Label } from '../ui/label';
 import { Input } from '../ui/input';
 import { DatePicker } from '../ui/date-picker';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
+import { ValidationSummary } from '../ValidationSummary';
+import { validateBasicInfo } from '../../utils/validation';
 
 export function BasicInfoStep() {
   const { register, watch, setValue } = useFormContext();
   const campaignStatus = watch('campaignStatus');
   const plantType = watch('plant_type');
+  const validation = validateBasicInfo(watch());
 
   // Handler for custom input
   const handleCustomPlantTypeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -16,6 +19,7 @@ export function BasicInfoStep() {
 
   return (
     <div className="space-y-8">
+      <ValidationSummary title="Basic Information" result={validation} />
       <div className="border-b border-border/20 pb-4">
         <h2 className="text-2xl font-bold text-primary mb-2">Basic Information</h2>
         <p className="text-muted-foreground">Provide essential details about your measurement campaign and organization.</p>

--- a/src/components/steps/LocationStep.tsx
+++ b/src/components/steps/LocationStep.tsx
@@ -9,11 +9,14 @@ import { Textarea } from '../ui/textarea';
 import { Map } from '../ui/map';
 import { Button } from '../ui/button';
 import type { IEATask43Schema } from '../../types/schema';
+import { ValidationSummary } from '../ValidationSummary';
+import { validateLocations } from '../../utils/validation';
 
 export function LocationStep() {
   const { register, setValue, watch } = useFormContext<IEATask43Schema>();
   const [isExpanded, setIsExpanded] = useState(true);
   const [expandedProfilerProps, setExpandedProfilerProps] = useState<Record<string, boolean>>({});
+  const validation = validateLocations(watch());
 
   const toggleExpand = () => {
     setIsExpanded(!isExpanded);
@@ -52,6 +55,7 @@ export function LocationStep() {
 
   return (
     <div className="space-y-8">
+      <ValidationSummary title="Measurement Location" result={validation} />
       <div className="flex justify-between items-center">
         <h2 className="text-2xl font-bold text-primary mb-2">Measurement Location</h2>
       </div>

--- a/src/components/steps/LoggerStep.tsx
+++ b/src/components/steps/LoggerStep.tsx
@@ -9,6 +9,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 import { Textarea } from '../ui/textarea';
 import type { IEATask43Schema, LoggerOEM } from '../../types/schema';
 import DynamicLoggerOptionalFields from './DynamicLoggerOptionalFields';
+import { ValidationSummary } from '../ValidationSummary';
+import { validateLoggers } from '../../utils/validation';
 
 export function LoggerStep() {
   const { register, setValue, watch } = useFormContext<IEATask43Schema>();
@@ -17,6 +19,7 @@ export function LoggerStep() {
     locations.reduce((acc, loc) => ({ ...acc, [loc.uuid]: true }), {})
   );
   const [expandedLoggers, setExpandedLoggers] = useState<{ [key: number]: boolean }>({});
+  const validation = validateLoggers(watch());
 
   const addLogger = (locationIndex: number) => {
     const currentLoggers = watch(`measurement_location.${locationIndex}.logger_main_config`) || [];
@@ -57,6 +60,7 @@ export function LoggerStep() {
 
   return (
     <div className="space-y-8">
+      <ValidationSummary title="Loggers" result={validation} />
       <h2 className="text-2xl font-bold text-primary mb-2">Logger Configuration</h2>
       <div className="text-muted-foreground mb-6">
         <p>A separate logger file is required for each data file which will be uploaded to the system. Data files should ensure consistency in timestamp conventions, averaging periods, etc. for all parameters contained within those files – care should be taken that this is the case when data files contain outputs from multiple sensors.</p>

--- a/src/components/steps/MeasurementStep.tsx
+++ b/src/components/steps/MeasurementStep.tsx
@@ -11,6 +11,8 @@ import type {
   StatisticType
 } from '@/types/schema';
 import { MeasurementTable, type BulkEditValues } from './sections/MeasurementTable';
+import { ValidationSummary } from '../ValidationSummary';
+import { validateMeasurements } from '../../utils/validation';
 
 interface CSVValidationError {
   type: 'error' | 'warning';
@@ -49,6 +51,7 @@ export function MeasurementStep() {
     unit: '',
     sensors: []
   });
+  const validation = validateMeasurements(watch());
 
   const addMeasurementPoint = (locationIndex: number, loggerIndex: number) => {
     const logger = watch(`measurement_location.${locationIndex}.logger_main_config.${loggerIndex}`);
@@ -620,6 +623,7 @@ export function MeasurementStep() {
 
   return (
     <div className="space-y-8">
+      <ValidationSummary title="Measurement Points" result={validation} />
       <h2 className="text-2xl font-bold text-primary mb-2">Measurement Points</h2>
 
       {locations.map((location, locationIndex) => (

--- a/src/components/steps/ReviewStep.tsx
+++ b/src/components/steps/ReviewStep.tsx
@@ -3,159 +3,28 @@ import { useFormContext } from 'react-hook-form';
 import { FileJson, Check, AlertCircle } from 'lucide-react';
 import { Button } from '../ui/button';
 import { cn } from '../../utils/cn';
-import type { IEATask43Schema, Sensor } from '../../types/schema';
+import type { IEATask43Schema } from '../../types/schema';
+import {
+  validateBasicInfo,
+  validateLocations,
+  validateLoggers,
+  validateMeasurements,
+  validateSensors,
+  type ValidationResult,
+} from '../../utils/validation';
 
 export function ReviewStep() {
   const { watch } = useFormContext<IEATask43Schema>();
   const formData = watch();
 
-  const validateData = () => {
-    const validationResults = {
-      basicInfo: validateBasicInfo(),
-      locations: validateLocations(),
-      loggers: validateLoggers(),
-      measurements: validateMeasurements(),
-      sensors: validateSensors()
-    };
-
-    return validationResults;
-  };
-
-  const validateBasicInfo = () => {
-    const { author, organisation, plant_name, plant_type, version, startDate, campaignStatus, endDate } = formData;
-    const issues: string[] = [];
-
-    if (!author) issues.push('Author is required');
-    if (!organisation) issues.push('Organisation is required');
-    if (!plant_name) issues.push('Plant name is required');
-    if (!plant_type) issues.push('Plant type is required');
-    if (!version) issues.push('Version is required');
-    if (!startDate) issues.push('Start date is required');
-    if (campaignStatus === 'historical' && !endDate) issues.push('End date is required');
-
+  const validateData = (): Record<string, ValidationResult> => {
+    const data = formData;
     return {
-      valid: issues.length === 0,
-      issues
-    };
-  };
-
-  const validateLocations = () => {
-    const issues: string[] = [];
-
-    if (!formData.measurement_location?.length) {
-      issues.push('At least one measurement location is required');
-      return { valid: false, issues };
-    }
-
-    formData.measurement_location.forEach((location, index) => {
-      if (!location.name) issues.push(`Location ${index + 1}: Name is required`);
-      if (!location.latitude_ddeg) issues.push(`Location ${index + 1}: Latitude is required`);
-      if (!location.longitude_ddeg) issues.push(`Location ${index + 1}: Longitude is required`);
-      if (!location.measurement_station_type_id) issues.push(`Location ${index + 1}: Station Type is required`);
-    });
-
-    return {
-      valid: issues.length === 0,
-      issues
-    };
-  };
-
-  const validateLoggers = () => {
-    const issues: string[] = [];
-
-    formData.measurement_location?.forEach((location, locIndex) => {
-      if (!location.logger_main_config?.length) {
-        issues.push(`Location ${locIndex + 1}: At least one logger is required`);
-        return;
-      }
-
-      location.logger_main_config.forEach((logger, logIndex) => {
-        if (!logger.logger_oem_id) {
-          issues.push(`Location ${locIndex + 1}, Logger ${logIndex + 1}: Logger Manufacturer is required`);
-        }
-        if (!logger.logger_model_name) {
-          issues.push(`Location ${locIndex + 1}, Logger ${logIndex + 1}: Model Name is required`);
-        }
-        if (!logger.logger_serial_number) {
-          issues.push(`Location ${locIndex + 1}, Logger ${logIndex + 1}: Serial number is required`);
-        }
-        if (!logger.date_from) {
-          issues.push(`Location ${locIndex + 1}, Logger ${logIndex + 1}: Date From is required`);
-        }
-        if (!logger.date_to) {
-          issues.push(`Location ${locIndex + 1}, Logger ${logIndex + 1}: Date To is required`);
-        }
-      });
-    });
-
-    return {
-      valid: issues.length === 0,
-      issues
-    };
-  };
-
-  const validateMeasurements = () => {
-    const issues: string[] = [];
-
-    formData.measurement_location?.forEach((location, locIndex) => {
-      if (!location.measurement_point?.length) {
-        issues.push(`Location ${locIndex + 1}: At least one measurement point is required`);
-        return;
-      }
-
-      location.measurement_point.forEach((point, pointIndex) => {
-        if (!point.name) {
-          issues.push(`Location ${locIndex + 1}, Point ${pointIndex + 1}: Name is required`);
-        }
-        if (!point.measurement_type_id) {
-          issues.push(`Location ${locIndex + 1}, Point ${pointIndex + 1}: Measurement type is required`);
-        }
-      });
-    });
-
-    return {
-      valid: issues.length === 0,
-      issues
-    };
-  };
-
-  const validateSensors = () => {
-    const issues: string[] = [];
-
-    formData.measurement_location?.forEach((location, locIndex) => {
-      // Require at least one sensor per location (skip undefined/null entries)
-      const validSensors = Array.isArray(location.sensors)
-        ? location.sensors.filter(Boolean)
-        : [];
-      if (validSensors.length === 0) {
-        issues.push(`Location ${locIndex + 1}: At least one sensor is required`);
-        return;
-      }
-      validSensors.forEach((sensor: Sensor, sensorIndex: number) => {
-        if (!sensor.oem) {
-          issues.push(`Location ${locIndex + 1}, Sensor ${sensorIndex + 1}: OEM is required`);
-        }
-        if (!sensor.model) {
-          issues.push(`Location ${locIndex + 1}, Sensor ${sensorIndex + 1}: Model is required`);
-        }
-        if (!sensor.serial_number) {
-          issues.push(`Location ${locIndex + 1}, Sensor ${sensorIndex + 1}: Serial Number is required`);
-        }
-        if (!sensor.sensor_type_id) {
-          issues.push(`Location ${locIndex + 1}, Sensor ${sensorIndex + 1}: Sensor Type is required`);
-        }
-        if (!sensor.date_from) {
-          issues.push(`Location ${locIndex + 1}, Sensor ${sensorIndex + 1}: Date From is required`);
-        }
-        if (!sensor.date_to) {
-          issues.push(`Location ${locIndex + 1}, Sensor ${sensorIndex + 1}: Date To is required`);
-        }
-      });
-    });
-
-    return {
-      valid: issues.length === 0,
-      issues
+      basicInfo: validateBasicInfo(data),
+      locations: validateLocations(data),
+      loggers: validateLoggers(data),
+      measurements: validateMeasurements(data),
+      sensors: validateSensors(data),
     };
   };
 

--- a/src/components/steps/SensorStep.tsx
+++ b/src/components/steps/SensorStep.tsx
@@ -9,6 +9,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 import { Textarea } from '../ui/textarea';
 import type { IEATask43Schema, SensorType, MeasurementType } from '../../types/schema';
 import DynamicSensorOptionalFields from './DynamicSensorOptionalFields';
+import { ValidationSummary } from '../ValidationSummary';
+import { validateSensors } from '../../utils/validation';
 
 // Define types for managing expanded states locally per location
 interface LocationExpandedState {
@@ -49,6 +51,8 @@ const TooltipWrapper = ({ children, text, className = "" }: { children: React.Re
 export function SensorsStep() {
   const { control, register, setValue, watch, formState: { errors } } = useFormContext<IEATask43Schema>();
   const allLocations = watch('measurement_location') || [];
+
+  const validation = validateSensors(watch());
 
   // States are now objects keyed by location index
   const [expandedSensors, setExpandedSensors] = useState<LocationExpandedState>({});
@@ -110,6 +114,7 @@ export function SensorsStep() {
 
   return (
     <div className="space-y-8">
+      <ValidationSummary title="Sensors" result={validation} />
       <h2 className="text-2xl font-bold text-primary mb-2">Sensors</h2>
       <div className="text-muted-foreground mb-6">
         Provide details for each sensor which produces data included in the logger file. It may be necessary to input multiple sensors for some parameters to reflect sensor swap outs throughout the measurement campaign e.g. in response to sensor failures or planned maintenance swap outs. A sensor entry should also be made for periods where no sensor was installed but the logger reports null data; in these cases, the OEM and model should be stated but the serial number stated as N/A and a note entered to indicate why this sensor is unavailable

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,143 @@
+import type { IEATask43Schema, Sensor } from '../types/schema';
+
+export interface ValidationResult {
+  valid: boolean;
+  issues: string[];
+}
+
+export function validateBasicInfo(data: IEATask43Schema): ValidationResult {
+  const { author, organisation, plant_name, plant_type, version, startDate, campaignStatus, endDate } = data;
+  const issues: string[] = [];
+
+  if (!author) issues.push('Author is required');
+  if (!organisation) issues.push('Organisation is required');
+  if (!plant_name) issues.push('Plant name is required');
+  if (!plant_type) issues.push('Plant type is required');
+  if (!version) issues.push('Version is required');
+  if (!startDate) issues.push('Start date is required');
+  if (campaignStatus === 'historical' && !endDate) issues.push('End date is required');
+
+  return {
+    valid: issues.length === 0,
+    issues,
+  };
+}
+
+export function validateLocations(data: IEATask43Schema): ValidationResult {
+  const issues: string[] = [];
+
+  if (!data.measurement_location?.length) {
+    issues.push('At least one measurement location is required');
+    return { valid: false, issues };
+  }
+
+  data.measurement_location.forEach((location, index) => {
+    if (!location.name) issues.push(`Location ${index + 1}: Name is required`);
+    if (!location.latitude_ddeg) issues.push(`Location ${index + 1}: Latitude is required`);
+    if (!location.longitude_ddeg) issues.push(`Location ${index + 1}: Longitude is required`);
+    if (!location.measurement_station_type_id) issues.push(`Location ${index + 1}: Station Type is required`);
+  });
+
+  return {
+    valid: issues.length === 0,
+    issues,
+  };
+}
+
+export function validateLoggers(data: IEATask43Schema): ValidationResult {
+  const issues: string[] = [];
+
+  data.measurement_location?.forEach((location, locIndex) => {
+    if (!location.logger_main_config?.length) {
+      issues.push(`Location ${locIndex + 1}: At least one logger is required`);
+      return;
+    }
+
+    location.logger_main_config.forEach((logger, logIndex) => {
+      if (!logger.logger_oem_id) {
+        issues.push(`Location ${locIndex + 1}, Logger ${logIndex + 1}: Logger Manufacturer is required`);
+      }
+      if (!logger.logger_model_name) {
+        issues.push(`Location ${locIndex + 1}, Logger ${logIndex + 1}: Model Name is required`);
+      }
+      if (!logger.logger_serial_number) {
+        issues.push(`Location ${locIndex + 1}, Logger ${logIndex + 1}: Serial number is required`);
+      }
+      if (!logger.date_from) {
+        issues.push(`Location ${locIndex + 1}, Logger ${logIndex + 1}: Date From is required`);
+      }
+      if (!logger.date_to) {
+        issues.push(`Location ${locIndex + 1}, Logger ${logIndex + 1}: Date To is required`);
+      }
+    });
+  });
+
+  return {
+    valid: issues.length === 0,
+    issues,
+  };
+}
+
+export function validateMeasurements(data: IEATask43Schema): ValidationResult {
+  const issues: string[] = [];
+
+  data.measurement_location?.forEach((location, locIndex) => {
+    if (!location.measurement_point?.length) {
+      issues.push(`Location ${locIndex + 1}: At least one measurement point is required`);
+      return;
+    }
+
+    location.measurement_point.forEach((point, pointIndex) => {
+      if (!point.name) {
+        issues.push(`Location ${locIndex + 1}, Point ${pointIndex + 1}: Name is required`);
+      }
+      if (!point.measurement_type_id) {
+        issues.push(`Location ${locIndex + 1}, Point ${pointIndex + 1}: Measurement type is required`);
+      }
+    });
+  });
+
+  return {
+    valid: issues.length === 0,
+    issues,
+  };
+}
+
+export function validateSensors(data: IEATask43Schema): ValidationResult {
+  const issues: string[] = [];
+
+  data.measurement_location?.forEach((location, locIndex) => {
+    const validSensors = Array.isArray(location.sensors)
+      ? location.sensors.filter(Boolean)
+      : [];
+    if (validSensors.length === 0) {
+      issues.push(`Location ${locIndex + 1}: At least one sensor is required`);
+      return;
+    }
+    validSensors.forEach((sensor: Sensor, sensorIndex: number) => {
+      if (!sensor.oem) {
+        issues.push(`Location ${locIndex + 1}, Sensor ${sensorIndex + 1}: OEM is required`);
+      }
+      if (!sensor.model) {
+        issues.push(`Location ${locIndex + 1}, Sensor ${sensorIndex + 1}: Model is required`);
+      }
+      if (!sensor.serial_number) {
+        issues.push(`Location ${locIndex + 1}, Sensor ${sensorIndex + 1}: Serial Number is required`);
+      }
+      if (!sensor.sensor_type_id) {
+        issues.push(`Location ${locIndex + 1}, Sensor ${sensorIndex + 1}: Sensor Type is required`);
+      }
+      if (!sensor.date_from) {
+        issues.push(`Location ${locIndex + 1}, Sensor ${sensorIndex + 1}: Date From is required`);
+      }
+      if (!sensor.date_to) {
+        issues.push(`Location ${locIndex + 1}, Sensor ${sensorIndex + 1}: Date To is required`);
+      }
+    });
+  });
+
+  return {
+    valid: issues.length === 0,
+    issues,
+  };
+}


### PR DESCRIPTION
## Summary
- centralize validation logic in utils
- show validation results inside each step
- add shared ValidationSummary component

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6859b77b1b40833096f75ac0e694d38a