### PR TITLE
Show step validation messages

### DIFF
--- a/src/components/steps/BasicInfoStep.tsx
+++ b/src/components/steps/BasicInfoStep.tsx
@@ -3,11 +3,14 @@ import { Label } from '../ui/label';
 import { Input } from '../ui/input';
 import { DatePicker } from '../ui/date-picker';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
+import { validateBasicInfo } from '../../utils/validation';
 
 export function BasicInfoStep() {
   const { register, watch, setValue } = useFormContext();
   const campaignStatus = watch('campaignStatus');
   const plantType = watch('plant_type');
+  const formData = watch();
+  const validation = validateBasicInfo(formData);
 
   // Handler for custom input
   const handleCustomPlantTypeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -20,6 +23,15 @@ export function BasicInfoStep() {
         <h2 className="text-2xl font-bold text-primary mb-2">Basic Information</h2>
         <p className="text-muted-foreground">Provide essential details about your measurement campaign and organization.</p>
       </div>
+      {!validation.valid && (
+        <div className="bg-red-50 border border-red-200 text-red-700 p-4 rounded-md">
+          <ul className="list-disc pl-5 text-sm">
+            {validation.issues.map((issue, idx) => (
+              <li key={idx}>{issue}</li>
+            ))}
+          </ul>
+        </div>
+      )}
       <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
         <div className="space-y-3">
           <Label htmlFor="author">Author <span className="required-asterisk">*</span></Label>

--- a/src/components/steps/LocationStep.tsx
+++ b/src/components/steps/LocationStep.tsx
@@ -9,11 +9,14 @@ import { Textarea } from '../ui/textarea';
 import { Map } from '../ui/map';
 import { Button } from '../ui/button';
 import type { IEATask43Schema } from '../../types/schema';
+import { validateLocations } from '../../utils/validation';
 
 export function LocationStep() {
   const { register, setValue, watch } = useFormContext<IEATask43Schema>();
   const [isExpanded, setIsExpanded] = useState(true);
   const [expandedProfilerProps, setExpandedProfilerProps] = useState<Record<string, boolean>>({});
+  const formData = watch();
+  const validation = validateLocations(formData);
 
   const toggleExpand = () => {
     setIsExpanded(!isExpanded);
@@ -55,6 +58,15 @@ export function LocationStep() {
       <div className="flex justify-between items-center">
         <h2 className="text-2xl font-bold text-primary mb-2">Measurement Location</h2>
       </div>
+      {!validation.valid && (
+        <div className="bg-red-50 border border-red-200 text-red-700 p-4 rounded-md">
+          <ul className="list-disc pl-5 text-sm">
+            {validation.issues.map((issue, idx) => (
+              <li key={idx}>{issue}</li>
+            ))}
+          </ul>
+        </div>
+      )}
 
       <div className="border border-border rounded-lg overflow-hidden">
         <div

--- a/src/components/steps/LoggerStep.tsx
+++ b/src/components/steps/LoggerStep.tsx
@@ -9,6 +9,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 import { Textarea } from '../ui/textarea';
 import type { IEATask43Schema, LoggerOEM } from '../../types/schema';
 import DynamicLoggerOptionalFields from './DynamicLoggerOptionalFields';
+import { validateLoggers } from '../../utils/validation';
 
 export function LoggerStep() {
   const { register, setValue, watch } = useFormContext<IEATask43Schema>();
@@ -17,6 +18,8 @@ export function LoggerStep() {
     locations.reduce((acc, loc) => ({ ...acc, [loc.uuid]: true }), {})
   );
   const [expandedLoggers, setExpandedLoggers] = useState<{ [key: number]: boolean }>({});
+  const formData = watch();
+  const validation = validateLoggers(formData);
 
   const addLogger = (locationIndex: number) => {
     const currentLoggers = watch(`measurement_location.${locationIndex}.logger_main_config`) || [];
@@ -58,6 +61,15 @@ export function LoggerStep() {
   return (
     <div className="space-y-8">
       <h2 className="text-2xl font-bold text-primary mb-2">Logger Configuration</h2>
+      {!validation.valid && (
+        <div className="bg-red-50 border border-red-200 text-red-700 p-4 rounded-md">
+          <ul className="list-disc pl-5 text-sm">
+            {validation.issues.map((issue, idx) => (
+              <li key={idx}>{issue}</li>
+            ))}
+          </ul>
+        </div>
+      )}
       <div className="text-muted-foreground mb-6">
         <p>A separate logger file is required for each data file which will be uploaded to the system. Data files should ensure consistency in timestamp conventions, averaging periods, etc. for all parameters contained within those files – care should be taken that this is the case when data files contain outputs from multiple sensors.</p>
       </div>

--- a/src/components/steps/MeasurementStep.tsx
+++ b/src/components/steps/MeasurementStep.tsx
@@ -11,6 +11,7 @@ import type {
   StatisticType
 } from '@/types/schema';
 import { MeasurementTable, type BulkEditValues } from './sections/MeasurementTable';
+import { validateMeasurements } from '../../utils/validation';
 
 interface CSVValidationError {
   type: 'error' | 'warning';
@@ -49,6 +50,8 @@ export function MeasurementStep() {
     unit: '',
     sensors: []
   });
+  const formData = watch();
+  const validation = validateMeasurements(formData);
 
   const addMeasurementPoint = (locationIndex: number, loggerIndex: number) => {
     const logger = watch(`measurement_location.${locationIndex}.logger_main_config.${loggerIndex}`);
@@ -621,6 +624,15 @@ export function MeasurementStep() {
   return (
     <div className="space-y-8">
       <h2 className="text-2xl font-bold text-primary mb-2">Measurement Points</h2>
+      {!validation.valid && (
+        <div className="bg-red-50 border border-red-200 text-red-700 p-4 rounded-md">
+          <ul className="list-disc pl-5 text-sm">
+            {validation.issues.map((issue, idx) => (
+              <li key={idx}>{issue}</li>
+            ))}
+          </ul>
+        </div>
+      )}
 
       {locations.map((location, locationIndex) => (
         <div key={location.uuid} className="border border-border rounded-lg overflow-hidden">

--- a/src/components/steps/ReviewStep.tsx
+++ b/src/components/steps/ReviewStep.tsx
@@ -3,164 +3,16 @@ import { useFormContext } from 'react-hook-form';
 import { FileJson, Check, AlertCircle } from 'lucide-react';
 import { Button } from '../ui/button';
 import { cn } from '../../utils/cn';
-import type { IEATask43Schema, Sensor } from '../../types/schema';
+import type { IEATask43Schema } from '../../types/schema';
+import { validateData } from '../../utils/validation';
 
 export function ReviewStep() {
   const { watch } = useFormContext<IEATask43Schema>();
   const formData = watch();
 
-  const validateData = () => {
-    const validationResults = {
-      basicInfo: validateBasicInfo(),
-      locations: validateLocations(),
-      loggers: validateLoggers(),
-      measurements: validateMeasurements(),
-      sensors: validateSensors()
-    };
-
-    return validationResults;
-  };
-
-  const validateBasicInfo = () => {
-    const { author, organisation, plant_name, plant_type, version, startDate, campaignStatus, endDate } = formData;
-    const issues: string[] = [];
-
-    if (!author) issues.push('Author is required');
-    if (!organisation) issues.push('Organisation is required');
-    if (!plant_name) issues.push('Plant name is required');
-    if (!plant_type) issues.push('Plant type is required');
-    if (!version) issues.push('Version is required');
-    if (!startDate) issues.push('Start date is required');
-    if (campaignStatus === 'historical' && !endDate) issues.push('End date is required');
-
-    return {
-      valid: issues.length === 0,
-      issues
-    };
-  };
-
-  const validateLocations = () => {
-    const issues: string[] = [];
-
-    if (!formData.measurement_location?.length) {
-      issues.push('At least one measurement location is required');
-      return { valid: false, issues };
-    }
-
-    formData.measurement_location.forEach((location, index) => {
-      if (!location.name) issues.push(`Location ${index + 1}: Name is required`);
-      if (!location.latitude_ddeg) issues.push(`Location ${index + 1}: Latitude is required`);
-      if (!location.longitude_ddeg) issues.push(`Location ${index + 1}: Longitude is required`);
-      if (!location.measurement_station_type_id) issues.push(`Location ${index + 1}: Station Type is required`);
-    });
-
-    return {
-      valid: issues.length === 0,
-      issues
-    };
-  };
-
-  const validateLoggers = () => {
-    const issues: string[] = [];
-
-    formData.measurement_location?.forEach((location, locIndex) => {
-      if (!location.logger_main_config?.length) {
-        issues.push(`Location ${locIndex + 1}: At least one logger is required`);
-        return;
-      }
-
-      location.logger_main_config.forEach((logger, logIndex) => {
-        if (!logger.logger_oem_id) {
-          issues.push(`Location ${locIndex + 1}, Logger ${logIndex + 1}: Logger Manufacturer is required`);
-        }
-        if (!logger.logger_model_name) {
-          issues.push(`Location ${locIndex + 1}, Logger ${logIndex + 1}: Model Name is required`);
-        }
-        if (!logger.logger_serial_number) {
-          issues.push(`Location ${locIndex + 1}, Logger ${logIndex + 1}: Serial number is required`);
-        }
-        if (!logger.date_from) {
-          issues.push(`Location ${locIndex + 1}, Logger ${logIndex + 1}: Date From is required`);
-        }
-        if (!logger.date_to) {
-          issues.push(`Location ${locIndex + 1}, Logger ${logIndex + 1}: Date To is required`);
-        }
-      });
-    });
-
-    return {
-      valid: issues.length === 0,
-      issues
-    };
-  };
-
-  const validateMeasurements = () => {
-    const issues: string[] = [];
-
-    formData.measurement_location?.forEach((location, locIndex) => {
-      if (!location.measurement_point?.length) {
-        issues.push(`Location ${locIndex + 1}: At least one measurement point is required`);
-        return;
-      }
-
-      location.measurement_point.forEach((point, pointIndex) => {
-        if (!point.name) {
-          issues.push(`Location ${locIndex + 1}, Point ${pointIndex + 1}: Name is required`);
-        }
-        if (!point.measurement_type_id) {
-          issues.push(`Location ${locIndex + 1}, Point ${pointIndex + 1}: Measurement type is required`);
-        }
-      });
-    });
-
-    return {
-      valid: issues.length === 0,
-      issues
-    };
-  };
-
-  const validateSensors = () => {
-    const issues: string[] = [];
-
-    formData.measurement_location?.forEach((location, locIndex) => {
-      // Require at least one sensor per location (skip undefined/null entries)
-      const validSensors = Array.isArray(location.sensors)
-        ? location.sensors.filter(Boolean)
-        : [];
-      if (validSensors.length === 0) {
-        issues.push(`Location ${locIndex + 1}: At least one sensor is required`);
-        return;
-      }
-      validSensors.forEach((sensor: Sensor, sensorIndex: number) => {
-        if (!sensor.oem) {
-          issues.push(`Location ${locIndex + 1}, Sensor ${sensorIndex + 1}: OEM is required`);
-        }
-        if (!sensor.model) {
-          issues.push(`Location ${locIndex + 1}, Sensor ${sensorIndex + 1}: Model is required`);
-        }
-        if (!sensor.serial_number) {
-          issues.push(`Location ${locIndex + 1}, Sensor ${sensorIndex + 1}: Serial Number is required`);
-        }
-        if (!sensor.sensor_type_id) {
-          issues.push(`Location ${locIndex + 1}, Sensor ${sensorIndex + 1}: Sensor Type is required`);
-        }
-        if (!sensor.date_from) {
-          issues.push(`Location ${locIndex + 1}, Sensor ${sensorIndex + 1}: Date From is required`);
-        }
-        if (!sensor.date_to) {
-          issues.push(`Location ${locIndex + 1}, Sensor ${sensorIndex + 1}: Date To is required`);
-        }
-      });
-    });
-
-    return {
-      valid: issues.length === 0,
-      issues
-    };
-  };
 
 
-  const validationResults = validateData();
+  const validationResults = validateData(formData);
   const isValid = Object.values(validationResults).every(result => result.valid);
 
   return (

--- a/src/components/steps/SensorStep.tsx
+++ b/src/components/steps/SensorStep.tsx
@@ -9,6 +9,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 import { Textarea } from '../ui/textarea';
 import type { IEATask43Schema, SensorType, MeasurementType } from '../../types/schema';
 import DynamicSensorOptionalFields from './DynamicSensorOptionalFields';
+import { validateSensors } from '../../utils/validation';
 
 // Define types for managing expanded states locally per location
 interface LocationExpandedState {
@@ -53,6 +54,8 @@ export function SensorsStep() {
   // States are now objects keyed by location index
   const [expandedSensors, setExpandedSensors] = useState<LocationExpandedState>({});
   const [expandedCalibrations, setExpandedCalibrations] = useState<LocationNestedExpandedState>({});
+  const formData = watch();
+  const validation = validateSensors(formData);
 
   // Adjust handlers to take locationIndex
   const toggleExpandSensor = (locationIndex: number, sensorsFieldId: string) => {
@@ -111,6 +114,15 @@ export function SensorsStep() {
   return (
     <div className="space-y-8">
       <h2 className="text-2xl font-bold text-primary mb-2">Sensors</h2>
+      {!validation.valid && (
+        <div className="bg-red-50 border border-red-200 text-red-700 p-4 rounded-md">
+          <ul className="list-disc pl-5 text-sm">
+            {validation.issues.map((issue, idx) => (
+              <li key={idx}>{issue}</li>
+            ))}
+          </ul>
+        </div>
+      )}
       <div className="text-muted-foreground mb-6">
         Provide details for each sensor which produces data included in the logger file. It may be necessary to input multiple sensors for some parameters to reflect sensor swap outs throughout the measurement campaign e.g. in response to sensor failures or planned maintenance swap outs. A sensor entry should also be made for periods where no sensor was installed but the logger reports null data; in these cases, the OEM and model should be stated but the serial number stated as N/A and a note entered to indicate why this sensor is unavailable
       </div>

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,154 @@
+import type { IEATask43Schema, Sensor } from '../types/schema';
+
+export interface ValidationResult {
+  valid: boolean;
+  issues: string[];
+}
+
+export const validateBasicInfo = (formData: IEATask43Schema): ValidationResult => {
+  const { author, organisation, plant_name, plant_type, version, startDate, campaignStatus, endDate } = formData;
+  const issues: string[] = [];
+
+  if (!author) issues.push('Author is required');
+  if (!organisation) issues.push('Organisation is required');
+  if (!plant_name) issues.push('Plant name is required');
+  if (!plant_type) issues.push('Plant type is required');
+  if (!version) issues.push('Version is required');
+  if (!startDate) issues.push('Start date is required');
+  if (campaignStatus === 'historical' && !endDate) issues.push('End date is required');
+
+  return {
+    valid: issues.length === 0,
+    issues
+  };
+};
+
+export const validateLocations = (formData: IEATask43Schema): ValidationResult => {
+  const issues: string[] = [];
+
+  if (!formData.measurement_location?.length) {
+    issues.push('At least one measurement location is required');
+    return { valid: false, issues };
+  }
+
+  formData.measurement_location.forEach((location, index) => {
+    if (!location.name) issues.push(`Location ${index + 1}: Name is required`);
+    if (!location.latitude_ddeg) issues.push(`Location ${index + 1}: Latitude is required`);
+    if (!location.longitude_ddeg) issues.push(`Location ${index + 1}: Longitude is required`);
+    if (!location.measurement_station_type_id) issues.push(`Location ${index + 1}: Station Type is required`);
+  });
+
+  return {
+    valid: issues.length === 0,
+    issues
+  };
+};
+
+export const validateLoggers = (formData: IEATask43Schema): ValidationResult => {
+  const issues: string[] = [];
+
+  formData.measurement_location?.forEach((location, locIndex) => {
+    if (!location.logger_main_config?.length) {
+      issues.push(`Location ${locIndex + 1}: At least one logger is required`);
+      return;
+    }
+
+    location.logger_main_config.forEach((logger, logIndex) => {
+      if (!logger.logger_oem_id) {
+        issues.push(`Location ${locIndex + 1}, Logger ${logIndex + 1}: Logger Manufacturer is required`);
+      }
+      if (!logger.logger_model_name) {
+        issues.push(`Location ${locIndex + 1}, Logger ${logIndex + 1}: Model Name is required`);
+      }
+      if (!logger.logger_serial_number) {
+        issues.push(`Location ${locIndex + 1}, Logger ${logIndex + 1}: Serial number is required`);
+      }
+      if (!logger.date_from) {
+        issues.push(`Location ${locIndex + 1}, Logger ${logIndex + 1}: Date From is required`);
+      }
+      if (!logger.date_to) {
+        issues.push(`Location ${locIndex + 1}, Logger ${logIndex + 1}: Date To is required`);
+      }
+    });
+  });
+
+  return {
+    valid: issues.length === 0,
+    issues
+  };
+};
+
+export const validateMeasurements = (formData: IEATask43Schema): ValidationResult => {
+  const issues: string[] = [];
+
+  formData.measurement_location?.forEach((location, locIndex) => {
+    if (!location.measurement_point?.length) {
+      issues.push(`Location ${locIndex + 1}: At least one measurement point is required`);
+      return;
+    }
+
+    location.measurement_point.forEach((point, pointIndex) => {
+      if (!point.name) {
+        issues.push(`Location ${locIndex + 1}, Point ${pointIndex + 1}: Name is required`);
+      }
+      if (!point.measurement_type_id) {
+        issues.push(`Location ${locIndex + 1}, Point ${pointIndex + 1}: Measurement type is required`);
+      }
+    });
+  });
+
+  return {
+    valid: issues.length === 0,
+    issues
+  };
+};
+
+export const validateSensors = (formData: IEATask43Schema): ValidationResult => {
+  const issues: string[] = [];
+
+  formData.measurement_location?.forEach((location, locIndex) => {
+    const validSensors = Array.isArray(location.sensors)
+      ? location.sensors.filter(Boolean)
+      : [];
+    if (validSensors.length === 0) {
+      issues.push(`Location ${locIndex + 1}: At least one sensor is required`);
+      return;
+    }
+    validSensors.forEach((sensor: Sensor, sensorIndex: number) => {
+      if (!sensor.oem) {
+        issues.push(`Location ${locIndex + 1}, Sensor ${sensorIndex + 1}: OEM is required`);
+      }
+      if (!sensor.model) {
+        issues.push(`Location ${locIndex + 1}, Sensor ${sensorIndex + 1}: Model is required`);
+      }
+      if (!sensor.serial_number) {
+        issues.push(`Location ${locIndex + 1}, Sensor ${sensorIndex + 1}: Serial Number is required`);
+      }
+      if (!sensor.sensor_type_id) {
+        issues.push(`Location ${locIndex + 1}, Sensor ${sensorIndex + 1}: Sensor Type is required`);
+      }
+      if (!sensor.date_from) {
+        issues.push(`Location ${locIndex + 1}, Sensor ${sensorIndex + 1}: Date From is required`);
+      }
+      if (!sensor.date_to) {
+        issues.push(`Location ${locIndex + 1}, Sensor ${sensorIndex + 1}: Date To is required`);
+      }
+    });
+  });
+
+  return {
+    valid: issues.length === 0,
+    issues
+  };
+};
+
+export const validateData = (formData: IEATask43Schema) => {
+  return {
+    basicInfo: validateBasicInfo(formData),
+    locations: validateLocations(formData),
+    loggers: validateLoggers(formData),
+    measurements: validateMeasurements(formData),
+    sensors: validateSensors(formData)
+  };
+};
+


### PR DESCRIPTION
## Summary
- centralize validation helpers
- import validation logic in step components
- display step-specific validation messages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6859b77b1b40833096f75ac0e694d38a